### PR TITLE
New PollIntervalDialog and fix for infinite loop of pings when exception occurs

### DIFF
--- a/SQL Developer 4 keepalive.jws
+++ b/SQL Developer 4 keepalive.jws
@@ -5,11 +5,13 @@
    <hash n="component-versions">
       <value n="oracle.adf.share.dt.migration.jps.JaznCredStoreMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.adf.share.dt.migration.wsm.PolicyAttachmentMigratorHelper" v="12.1.2.0.0"/>
+      <value n="oracle.adfdt.controller.adfc.source.migration.SavePointDataSourceForWLSMigrator" v="11.1.1.1.0"/>
       <value n="oracle.adfdtinternal.model.ide.security.extension.AdfSecurityMigrator" v="11.1.1.1.0.13"/>
-      <value n="oracle.ide.model.Project" v="11.1.1.1.0;12.1.2.0.0"/>
+      <value n="oracle.ide.model.Project" v="11.1.1.1.0;12.1.2.0.0;12.1.3.0.0"/>
       <value n="oracle.jbo.dt.jdevx.deployment.JbdProjectMigrator" v="11.1.2.0.0"/>
       <value n="oracle.jdevimpl.appresources.ApplicationSrcDirMigrator" v="11.1.2.0.0"/>
       <value n="oracle.jdevimpl.deploy.migrators.JeeDeploymentMigrator" v="12.1.2.0.0"/>
+      <value n="oracle.jdevimpl.xml.oc4j.jps.JpsConfigMigratorHelper" v="11.1.1.1.0.1"/>
       <value n="oracle.jdevimpl.xml.wl.WeblogicMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.mds.internal.dt.deploy.base.MarMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.mds.internal.dt.ide.migrator.MDSConfigMigratorHelper" v="11.1.1.0.5313"/>

--- a/SQL Developer 4 keepalive/SQL Developer 4 keepalive.jpr
+++ b/SQL Developer 4 keepalive/SQL Developer 4 keepalive.jpr
@@ -1,32 +1,47 @@
 <?xml version = '1.0' encoding = 'UTF-8'?>
 <jpr:project xmlns:jpr="http://xmlns.oracle.com/ide/project">
    <hash n="component-versions">
+      <value n="oracle.adfdt.controller.adfc.source.migration.AdfControllerSchemaMigrator" v="11.1.1.1.0"/>
+      <value n="oracle.adfdt.controller.common.migrator.ProjectMigrator" v="11.1.1.1.0"/>
+      <value n="oracle.adfdt.controller.jsf2.diagram.migrate.JsfNodeMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.adfdt.controller.migrate.TrinidadDatabindingsProjectMigrator" v="11.1.2.0.0"/>
       <value n="oracle.adfdtinternal.dvt.datapresdt.migration.DVTDataMapMigrator" v="11.1.1.1.0.3"/>
+      <value n="oracle.adfdtinternal.dvt.datapresdt.migration.DVTWebAppConfigurationMigrator" v="12.1.3.0.0"/>
+      <value n="oracle.adfdtinternal.model.ide.migration.ProjectMigrator" v="11.1.1.1.0.11.1.1"/>
       <value n="oracle.adfdtinternal.model.ide.security.wizard.FormPageMigrator" v="11.1.1.0.0"/>
       <value n="oracle.adfdtinternal.model.ide.security.wizard.JpsFilterMigrator" v="11.1.1.1.0"/>
+      <value n="oracle.adfdtinternal.model.ide.xmled.migration.ADFNodeMigrator" v="11.1.1.1.0.5"/>
+      <value n="oracle.adfdtinternal.model.ide.xmled.migration.PageDefinitionParameterValueMigrator" v="11.1.1.1.0.5"/>
+      <value n="oracle.adfdtinternal.model.ide.xmled.migration.WebXmlMigrator" v="11.1.1.1.0"/>
       <value n="oracle.adfdtinternal.view.common.migration.wizards.MigrationHelper" v="11.1.1.1.0.3"/>
+      <value n="oracle.adfdtinternal.view.rich.binding.migration.JarResourceMigrator" v="11.1.1.1.0"/>
       <value n="oracle.adfdtinternal.view.rich.migration.ComponentIdNodeMigratorHelper" v="11.1.1.1.0.01"/>
       <value n="oracle.adfdtinternal.view.rich.migration.FacesLibraryVersionMigrator" v="11.1.1.1.0.1"/>
-      <value n="oracle.ide.model.Project" v="12.1.2.0.0"/>
+      <value n="oracle.ide.model.Project" v="12.1.2.0.0;12.1.3.0.0"/>
       <value n="oracle.ide.model.ResourcePathsMigrator" v="11.1.1.1.0"/>
-      <value n="oracle.ideimpl.model.TechnologyScopeUpdateMigrator" v="11.1.2.0.0.4"/>
+      <value n="oracle.ideimpl.model.TechnologyScopeUpdateMigrator" v="11.1.2.0.0.4;11.1.2.0.0.5"/>
+      <value n="oracle.jbo.dt.jclient.migrator.JCProjectMigrator" v="11.1.1.1.0"/>
       <value n="oracle.jbo.dt.jdevx.deployment.JbdProjectMigrator" v="11.1.2.0.0"/>
+      <value n="oracle.jbo.dt.jdevx.ui.appnav.APAdfConfigMigrator" v="11.1.2.0.0"/>
       <value n="oracle.jbo.dt.jdevx.ui.appnav.APProjectMigrator" v="11.1.1.0.1.5"/>
       <value n="oracle.jbo.dt.migrate.ResourceBundlePathMigrator" v="11.1.1.0.1.5"/>
       <value n="oracle.jbo.dt.migration.ServiceInterfaceMigrator" v="11.1.1.1.0"/>
       <value n="oracle.jdeveloper.dbmodeler.Migration" v="12.1.1.0.0"/>
+      <value n="oracle.jdeveloper.ejb.EjbMigrator" v="11.1.1.1.0"/>
       <value n="oracle.jdeveloper.library.ProjectLibraryMigrator" v="11.1.1.1.0"/>
       <value n="oracle.jdeveloper.model.OutputDirectoryMigrator" v="11.1.1.1.0"/>
+      <value n="oracle.jdevimpl.deploy.jps.JpsDataMigrator" v="11.1.1.1.0"/>
       <value n="oracle.jdevimpl.deploy.migrators.DeploymentMigrator" v="12.1.2.0.1"/>
       <value n="oracle.jdevimpl.jsp.JspMigrator" v="11.1.1"/>
       <value n="oracle.jdevimpl.offlinedb.migration.OfflineDBProjectMigrator" v="12.1.1.0.0"/>
+      <value n="oracle.jdevimpl.resourcebundle.XliffAddin$XliffMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.jdevimpl.webapp.jsp.libraries.JspLibraryMigrator" v="11.1.1.1.4"/>
       <value n="oracle.jdevimpl.webapp.jsp.taglibraries.trinidad.migration.TrinidadLibraryVersionMigrator" v="11.1.1.1.0.1"/>
       <value n="oracle.jdevimpl.webapp.WebAppContentSetNodeMigratorHelper" v="11.1.1"/>
       <value n="oracle.jdevimpl.webapp.WebAppProjectNodeMigratorHelper" v="12.1.2.0.0"/>
       <value n="oracle.jdevimpl.webservices.rest.migration.RestLibraryMigrator" v="12.1.1.0.0"/>
       <value n="oracle.jdevimpl.webservices.rest.migration.RestPathMigrator" v="11.1.2.0.0"/>
+      <value n="oracle.jdevimpl.webservices.WebServicesMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.jdevimpl.xml.wl.WeblogicMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.modeler.bmmigrate.management.Migration" v="11.1.1.1.0"/>
       <value n="oracle.toplink.workbench.addin.migration.PersistenceProjectMigrator" v="11.1.1.1.0"/>

--- a/SQL Developer 4 keepalive/src/META-INF/MANIFEST.MF
+++ b/SQL Developer 4 keepalive/src/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-Version: 1.0.0
 Bundle-SymbolicName: keepalive
 Bundle-ClassPath: .
 Require-Bundle: oracle.ide,
- oracle.javatools,
  oracle.icons,
- oracle.sqldeveloper
+ oracle.sqldeveloper,
+ oracle.javatools,
+ oracle.db-api

--- a/SQL Developer 4 keepalive/src/keepalive/KeepaliveController.java
+++ b/SQL Developer 4 keepalive/src/keepalive/KeepaliveController.java
@@ -17,12 +17,17 @@ public class KeepaliveController implements Controller {
     @Override
     public boolean handleEvent(IdeAction ideAction, Context context) {
         if (!started) {
-            String timeout = null;
-            timeout = JOptionPane.showInputDialog(null, "Please input the desired timeout (in seconds)");
-            started = true;
-            ConnectionPinger conn = new ConnectionPinger(timeout);
-            keeper = new Thread(conn);
-            keeper.start();
+            //String timeout = JOptionPane.showInputDialog(null, "Please input the desired timeout (in seconds)");
+            PollIntervalDialog dlg = new PollIntervalDialog(null);
+            dlg.setVisible(true);
+            
+            Integer pollInterval = dlg.getPollInterval();
+            if(pollInterval != null) {
+                started = true;
+                ConnectionPinger conn = new ConnectionPinger(pollInterval);
+                keeper = new Thread(conn);
+                keeper.start();
+            }
         } else {
             started = false;
             keeper.interrupt();

--- a/SQL Developer 4 keepalive/src/keepalive/PollIntervalDialog.java
+++ b/SQL Developer 4 keepalive/src/keepalive/PollIntervalDialog.java
@@ -1,0 +1,154 @@
+package keepalive;
+
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JTextField;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DocumentFilter;
+import javax.swing.text.PlainDocument;
+
+public class PollIntervalDialog extends JDialog {
+
+    private static final long serialVersionUID = 931087028121895189L;
+    
+    private JTextField textField;
+	private JOptionPane optionPane;
+	private Integer pollInterval;
+	
+	//minimal value for poll interval in seconds
+	private final Integer minPollInterval = 60;
+	
+	//maximal value for poll interval in seconds
+	private final Integer maxPollInterval = 43200;  //12h
+	
+	private static final String OK_STRING = "OK";
+	private static final String CANCEL_STRING = "Cancel";
+	
+	public PollIntervalDialog(JFrame parent) {
+		super(parent, true);
+		setTitle("KeepAlive");
+		initDialog();
+		pack();
+	}
+	
+	private void initDialog() {
+		textField = new JTextField(20);
+		PlainDocument doc = (PlainDocument) textField.getDocument();
+		doc.setDocumentFilter(new NumberFilter());
+		
+		Object[] controls = {"Specify poll interval (in seconds):", textField};
+		Object[] options = {OK_STRING, CANCEL_STRING};
+
+		optionPane = new JOptionPane(controls,
+							JOptionPane.QUESTION_MESSAGE,
+							JOptionPane.YES_NO_OPTION,
+							null,
+							options,
+							options[0]);
+		setContentPane(optionPane);
+		
+		addComponentListener(new ComponentAdapter() {
+			@Override
+            public void componentShown(ComponentEvent ce) {
+                textField.requestFocusInWindow();
+            }
+        });
+		
+		optionPane.addPropertyChangeListener(new PropertyChangeListener() {
+			@Override
+			public void propertyChange(PropertyChangeEvent e) {
+				
+				if(isVisible() && JOptionPane.VALUE_PROPERTY.equals(e.getPropertyName())) {
+					
+					Object value = optionPane.getValue();
+
+					if (value == JOptionPane.UNINITIALIZED_VALUE) {
+						return;
+					}
+					
+					switch(value.toString()) {
+						case OK_STRING:
+							String v = textField.getText();
+							if(checkValue(v)) {
+								pollInterval = Integer.parseInt(v, 10);
+								setVisible(false);
+							} else {
+								//to let PropertyChangeEvent fire next time the user presses button
+								optionPane.setValue(JOptionPane.UNINITIALIZED_VALUE);
+							}
+							break;
+							
+						case CANCEL_STRING:
+							pollInterval = null;
+							setVisible(false);
+							break;
+					}
+				}
+			}
+			
+		});
+	}
+	
+	private boolean checkValue(String txt) {
+		
+		if(txt != null && txt.length() > 0) {
+			//avoid parsing possibly very long string into integer
+			if(txt.length() <= maxPollInterval.toString().length()) {
+				try {
+
+					Integer value = Integer.parseInt(txt, 10);
+					if(value >= minPollInterval && value <= maxPollInterval) {
+						return true;
+					}
+				} catch(NumberFormatException e) {
+				}
+			}
+		}
+		
+		JOptionPane.showMessageDialog(this,
+							"Please specify value in range " 
+									+ minPollInterval + " - " + maxPollInterval,
+							"Wrong value",
+							JOptionPane.ERROR_MESSAGE);
+		return false;
+	}
+	
+	public Integer getPollInterval() {
+		return pollInterval;
+	}
+}
+
+class NumberFilter extends DocumentFilter {
+	private static final Pattern pattern = Pattern.compile("^[0-9]+$");
+	
+	@Override
+	public void replace(DocumentFilter.FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException {
+		if(isNumber(text))
+			super.replace(fb, offset, length, text, attrs);
+		else {
+			java.awt.Toolkit.getDefaultToolkit().beep();
+		}
+	}
+
+	@Override
+	public void insertString(DocumentFilter.FilterBypass fb, int offset, String text, AttributeSet attr) throws BadLocationException {
+		if(isNumber(text)) {
+			super.insertString(fb, offset, text, attr);
+		} else {
+			java.awt.Toolkit.getDefaultToolkit().beep();
+		}
+	}
+	
+	private static boolean isNumber(String s) {
+		Matcher m = pattern.matcher(s);
+		return m.matches();
+	}	
+}


### PR DESCRIPTION
New dialog for asking for pull interval timeout with filter so only numbers can be inserted into the textfield.

Corrected problem with infinite loop when exception occurs when keepalive is started. There was no Thread.sleep() call in the last catch clause which caused hundreds/thousands ping requests per second.

Added dependency to oracle.db-api because without it JDeveloper 12.1.3.0.0 complains about missing file for class DBException.

Project files were automatically updated by JDeveloper to its new version so comitted them to the repo.
